### PR TITLE
Fixed Config saving without ".cfg"

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -116,7 +116,7 @@ const bool Configuration::LoadPreset(std::string filename, bool reset = false) {
 // Save configuration values to a file.
 const bool Configuration::SavePreset(std::string filename) {
 	// Resolve the relative filename to a full path.
-	std::string output_filename = this->base_folder + "\\" + filename;
+	std::string output_filename = this->base_folder + "\\" + filename + ".cfg";
 
 	// Open the output configuration file for writing.
 	std::ofstream output_file = std::ofstream(output_filename);


### PR DESCRIPTION
It does not find the Config without ".cfg" at the end

//Edit 
-nvm this only works if the File is saved the first time, if you save the same file again it creates a new one with " .cfg.cfg"