### PR TITLE
Fixed Saving Config

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -49,7 +49,7 @@ const std::vector<std::string> Configuration::GetPresets() {
 // Load configuration values from a file.
 const bool Configuration::LoadPreset(std::string filename, bool reset = false) {
 	// Resolve the relative filename to a full path.
-	std::string input_filename = this->base_folder + "\\" + filename + ".cfg";
+	std::string input_filename = this->base_folder + "\\" + filename;
 
 	// Open the input configuration file for reading.
 	std::ifstream input_file = std::ifstream(input_filename);

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -49,7 +49,7 @@ const std::vector<std::string> Configuration::GetPresets() {
 // Load configuration values from a file.
 const bool Configuration::LoadPreset(std::string filename, bool reset = false) {
 	// Resolve the relative filename to a full path.
-	std::string input_filename = this->base_folder + "\\" + filename;
+	std::string input_filename = this->base_folder + "\\" + filename + ".cfg";
 
 	// Open the input configuration file for reading.
 	std::ifstream input_file = std::ifstream(input_filename);
@@ -113,10 +113,61 @@ const bool Configuration::LoadPreset(std::string filename, bool reset = false) {
 	return true;
 }
 
+// Edit configuration valuese.
+const bool Configuration::EditPreset(std::string filename) {
+	// Resolve the relative filename to a full path.
+	std::string output_filename = this->base_folder + "\\" + filename;
+
+	// Open the output configuration file for writing.
+	std::ofstream output_file = std::ofstream(output_filename);
+	
+	if (!output_file.good())
+		return false;
+
+	// Create a JSON object to serialize the configuration.
+	nlohmann::json preset;
+	
+	for (const auto& item: this->item_config) {
+		const EconomyItem_t& item_config = item.second;
+
+		if (!item_config.is_valid)
+			continue;
+
+		std::string item_key = std::to_string(item.first);
+
+		if (item_config.entity_quality != -1)
+			preset["items"][item_key]["entity_quality"] = item_config.entity_quality;
+
+		if (item_config.fallback_seed != -1)
+			preset["items"][item_key]["fallback_seed"] = item_config.fallback_seed;
+
+		if (item_config.fallback_paint_kit != -1)
+			preset["items"][item_key]["fallback_paint_kit"] = item_config.fallback_paint_kit;
+
+		if (item_config.fallback_stattrak != -1)
+			preset["items"][item_key]["fallback_stattrak"] = item_config.fallback_stattrak;
+
+		if (item_config.fallback_wear != -1)
+			preset["items"][item_key]["fallback_wear"] = item_config.fallback_wear;
+
+		if (item_config.item_definition_index != -1)
+			preset["items"][item_key]["item_definition_index"] = item_config.item_definition_index;
+
+		if (strlen(item_config.custom_name) != 0)
+			preset["items"][item_key]["custom_name"] = item_config.custom_name;
+	}
+
+	// Write the contents to disk with pretty formatting.
+	output_file << std::setw(4) << preset << std::endl;
+	output_file.close();
+	
+	return true;
+}
+
 // Save configuration values to a file.
 const bool Configuration::SavePreset(std::string filename) {
 	// Resolve the relative filename to a full path.
-	std::string output_filename = this->base_folder + "\\" + filename;
+	std::string output_filename = this->base_folder + "\\" + filename + ".cfg";
 
 	// Open the output configuration file for writing.
 	std::ofstream output_file = std::ofstream(output_filename);

--- a/src/Configuration.hpp
+++ b/src/Configuration.hpp
@@ -33,10 +33,11 @@ class Configuration {
 		std::string GetBaseFolder();
 		const bool SetBaseFolder(HMODULE);
 
-		// Save & load presets from disk.
+		// Save, Load & Edit presets from disk.
 		const std::vector<std::string> GetPresets();
 		const bool LoadPreset(std::string, bool);
 		const bool SavePreset(std::string);
+	 	const bool EditPreset(std::string);
 		const bool RemovePreset(std::string);
 
 		// Weapon related functions.

--- a/src/Interface.hpp
+++ b/src/Interface.hpp
@@ -107,7 +107,7 @@ inline void RenderInterface() {
 
 				if (ImGui::Button(std::string("Save##").append(preset).c_str())) {
 					// Overwrite this file with current item settings.
-					config.SavePreset(preset);
+					config.EditPreset(preset);
 				}
 
 				ImGui::SameLine();


### PR DESCRIPTION
Fixed not Saving the Config as ".cfg" (If you Save it for the First Time)
New Function to Edit existing Config File
(-Dont know if this is a good method cause i'm not that good in C++ but this fixed it for me)

You could also put this into the "Interface.hpp" for Easy Style Editing 
-http://pastebin.com/QZUNYM4K
-Style Preview = https://i.gyazo.com/320e3513fcb238a102b15b60adbfd1f6.png

I also changed some other stuff if you wanna look into it
https://github.com/LeagueRaINi/chameleon-ng/tree/CustomFeatures