### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/src/Hooks/FrameStageNotify.hpp
+++ b/src/Hooks/FrameStageNotify.hpp
@@ -76,7 +76,7 @@ void __fastcall hkFrameStageNotify(IBaseClientDLL* thisptr, void* edx, ClientFra
 					*weapon->GetEntityQuality() = weapon_config.entity_quality;
 
 				// Apply custom name tag.
-				if (weapon_config.custom_name)
+				if (*weapon_config.custom_name)
 					snprintf(weapon->GetCustomName(), 32, "%s", weapon_config.custom_name);
 
 				// Apply the paint kit.


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V600](https://www.viva64.com/en/w/v600/) Consider inspecting the condition. The 'weapon_config.custom_name' pointer is always not equal to NULL. framestagenotify.hpp 79